### PR TITLE
Remove Pipfile.lock from pyup

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -29,7 +29,6 @@ requirements:
   - src/python/psic/requirements-dev.txt
   - src/python/psic/requirements-docs.txt
   - src/python/psic/requirements.txt
-  - Pipfile.lock
 
 # add a label to pull requests, default is not set
 # requires private repo permissions, even on public repos


### PR DESCRIPTION
Since pyup already checks the traditional requirements.txt files for updates, and the package uses those primarily, the Pipfile.lock is not really ever used, and shadows the same requirements from the requirements docs. This leads to pyup showing duplicate updates when a package becomes out of date!